### PR TITLE
Use enum members in tests as well (#6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 *.py[cod]
 *$py.class
+## Python virtual environment
+venv/
 
 ## ebrowse - class hierarchy database
 BROWSE

--- a/contrib/PythonPreprocessor/test_MBDynLib.py
+++ b/contrib/PythonPreprocessor/test_MBDynLib.py
@@ -87,15 +87,10 @@ class TestConstDrive(unittest.TestCase):
 
 class TestLinearElastic(unittest.TestCase):
     def setUp(self):
-        self.scalar_law = l.LinearElastic(law_type="scalar isotropic law", stiffness=1e9)
-        self.vector_3d_law = l.LinearElastic(law_type="3D isotropic law", stiffness=1e9)
-        self.vector_6d_law = l.LinearElastic(law_type="6D isotropic law", stiffness=1e9)
+        self.scalar_law = l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, stiffness=1e9)
+        self.vector_3d_law = l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.D3_ISOTROPIC_LAW, stiffness=1e9)
+        self.vector_6d_law = l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.D6_ISOTROPIC_LAW, stiffness=1e9)
 
-    def test_name(self):
-        self.assertEqual(self.scalar_law.law_type, l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW)
-        self.assertEqual(self.vector_3d_law.law_type, l.ConstitutiveLaw.LawType.D3_ISOTROPIC_LAW)
-        self.assertEqual(self.vector_6d_law.law_type, l.ConstitutiveLaw.LawType.D6_ISOTROPIC_LAW)
-        
     def test_const_law_name(self):
         self.assertEqual(self.scalar_law.const_law_header(), 'linear elastic')
         self.assertEqual(self.vector_3d_law.const_law_header(), 'linear elastic isotropic')
@@ -112,9 +107,9 @@ class TestLinearElastic(unittest.TestCase):
             l.LinearElastic(law_type='INVALID_LAW_TYPE', stiffness=1e9)
 
     def test_different_stiffness_values(self):
-        small_stiffness = l.LinearElastic(law_type="scalar isotropic law", stiffness=1e-9)
-        large_stiffness = l.LinearElastic(law_type="scalar isotropic law", stiffness=1e12)
-        zero_stiffness = l.LinearElastic(law_type="scalar isotropic law", stiffness=0)
+        small_stiffness = l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, stiffness=1e-9)
+        large_stiffness = l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, stiffness=1e12)
+        zero_stiffness = l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, stiffness=0)
         self.assertEqual(small_stiffness.stiffness, 1e-9)
         self.assertEqual(large_stiffness.stiffness, 1e12)
         self.assertEqual(zero_stiffness.stiffness, 0)
@@ -122,35 +117,35 @@ class TestLinearElastic(unittest.TestCase):
     @unittest.skipIf(pydantic is None, "depends on library, since it doesn't prevent correct models from running")
     def test_missing_arguments(self):
         with self.assertRaises(Exception):
-            l.LinearElastic(law_type="scalar isotropic law")
+            l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW)
         with self.assertRaises(Exception):
             l.LinearElastic(stiffness=1e9)
 
     @unittest.skipIf(pydantic is None, "depends on library, since it doesn't prevent correct models from running")
     def test_invalid_stiffness_type(self):
         with self.assertRaises(Exception):
-            l.LinearElastic(law_type="scalar isotropic law", stiffness="invalid")
+            l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, stiffness="invalid")
         with self.assertRaises(Exception):
-            l.LinearElastic(law_type="scalar isotropic law", stiffness=None)
+            l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, stiffness=None)
 
     @unittest.skipIf(pydantic is None, "depends on library, since it doesn't prevent correct models from running")
     def test_extra_arguments(self):
         with self.assertRaises(Exception):
-            l.LinearElastic(law_type="scalar isotropic law", stiffness=1e9, foo=1.0)
+            l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, stiffness=1e9, foo=1.0)
 
     def test_str_with_different_stiffness(self):
-        small_stiffness = l.LinearElastic(law_type="scalar isotropic law", stiffness=1e-9)
-        large_stiffness = l.LinearElastic(law_type="scalar isotropic law", stiffness=1e12)
-        zero_stiffness = l.LinearElastic(law_type="scalar isotropic law", stiffness=0)
+        small_stiffness = l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, stiffness=1e-9)
+        large_stiffness = l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, stiffness=1e12)
+        zero_stiffness = l.LinearElastic(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, stiffness=0)
         self.assertEqual(str(small_stiffness), f'{small_stiffness.const_law_header()}, 1e-09')
         self.assertEqual(str(large_stiffness), f'{large_stiffness.const_law_header()}, 1000000000000.0')
         self.assertEqual(str(zero_stiffness), f'{zero_stiffness.const_law_header()}, 0.0')
 
 class TestLinearViscousGeneric(unittest.TestCase):
     def setUp(self):
-        self.scalar_law = l.LinearViscousGeneric(law_type="scalar isotropic law", viscosity=1e9)
-        self.vector_3d_law = l.LinearViscousGeneric(law_type="3D isotropic law", viscosity=[[1e9, 0, 0], [0, 1e9, 0], [0, 0, 1e9]])
-        self.vector_6d_law = l.LinearViscousGeneric(law_type="6D isotropic law", viscosity=[[1e9, 0, 0, 0, 0, 0], [0, 1e9, 0, 0, 0, 0], [0, 0, 1e9, 0, 0, 0], [0, 0, 0, 1e9, 0, 0], [0, 0, 0, 0, 1e9, 0], [0, 0, 0, 0, 0, 1e9]])
+        self.scalar_law = l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, viscosity=1e9)
+        self.vector_3d_law = l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.D3_ISOTROPIC_LAW, viscosity=[[1e9, 0, 0], [0, 1e9, 0], [0, 0, 1e9]])
+        self.vector_6d_law = l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.D6_ISOTROPIC_LAW, viscosity=[[1e9, 0, 0, 0, 0, 0], [0, 1e9, 0, 0, 0, 0], [0, 0, 1e9, 0, 0, 0], [0, 0, 0, 1e9, 0, 0], [0, 0, 0, 0, 1e9, 0], [0, 0, 0, 0, 0, 1e9]])
 
     def test_name(self):
         self.assertEqual(self.scalar_law.law_type, l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW)
@@ -173,9 +168,9 @@ class TestLinearViscousGeneric(unittest.TestCase):
             l.LinearViscousGeneric(law_type='INVALID_LAW_TYPE', viscosity=1e9)
 
     def test_different_viscosity_values(self):
-        small_viscosity = l.LinearViscousGeneric(law_type="scalar isotropic law", viscosity=1e-9)
-        large_viscosity = l.LinearViscousGeneric(law_type="scalar isotropic law", viscosity=1e12)
-        zero_viscosity = l.LinearViscousGeneric(law_type="scalar isotropic law", viscosity=0)
+        small_viscosity = l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, viscosity=1e-9)
+        large_viscosity = l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, viscosity=1e12)
+        zero_viscosity = l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, viscosity=0)
         self.assertEqual(small_viscosity.viscosity, 1e-9)
         self.assertEqual(large_viscosity.viscosity, 1e12)
         self.assertEqual(zero_viscosity.viscosity, 0)
@@ -183,26 +178,26 @@ class TestLinearViscousGeneric(unittest.TestCase):
     @unittest.skipIf(pydantic is None, "depends on library, since it doesn't prevent correct models from running")
     def test_missing_arguments(self):
         with self.assertRaises(Exception):
-            l.LinearViscousGeneric(law_type="scalar isotropic law")
+            l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW)
         with self.assertRaises(Exception):
             l.LinearViscousGeneric(viscosity=1e9)
 
     @unittest.skipIf(pydantic is None, "depends on library, since it doesn't prevent correct models from running")
     def test_invalid_viscosity_type(self):
         with self.assertRaises(Exception):
-            l.LinearViscousGeneric(law_type="scalar isotropic law", viscosity="invalid")
+            l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, viscosity="invalid")
         with self.assertRaises(Exception):
-            l.LinearViscousGeneric(law_type="scalar isotropic law", viscosity=None)
+            l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, viscosity=None)
 
     @unittest.skipIf(pydantic is None, "depends on library, since it doesn't prevent correct models from running")
     def test_extra_arguments(self):
         with self.assertRaises(Exception):
-            l.LinearViscousGeneric(law_type="scalar isotropic law", viscosity=1e9, foo=1.0)
+            l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, viscosity=1e9, foo=1.0)
 
     def test_str_with_different_viscosity(self):
-        small_viscosity = l.LinearViscousGeneric(law_type="scalar isotropic law", viscosity=1e-9)
-        large_viscosity = l.LinearViscousGeneric(law_type="scalar isotropic law", viscosity=1e12)
-        zero_viscosity = l.LinearViscousGeneric(law_type="scalar isotropic law", viscosity=0)
+        small_viscosity = l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, viscosity=1e-9)
+        large_viscosity = l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, viscosity=1e12)
+        zero_viscosity = l.LinearViscousGeneric(law_type=l.ConstitutiveLaw.LawType.SCALAR_ISOTROPIC_LAW, viscosity=0)
         self.assertEqual(str(small_viscosity), f'{small_viscosity.const_law_header()}, 1e-09')
         self.assertEqual(str(large_viscosity), f'{large_viscosity.const_law_header()}, 1000000000000.0')
         self.assertEqual(str(zero_viscosity), f'{zero_viscosity.const_law_header()}, 0.0')


### PR DESCRIPTION
Continuing with the idea in #6 of not copying strings but using enums in tests as well