### PR TITLE
Adjustments to NamedConstitutiveLaw

### DIFF
--- a/contrib/PythonPreprocessor/MBDynLib.py
+++ b/contrib/PythonPreprocessor/MBDynLib.py
@@ -5989,30 +5989,31 @@ class InvariantAngularWrapper(ConstitutiveLaw):
         base_str += f',\n\t{str(self.wrapped_const_law)}'
         return base_str
     
-class NamedConstitutiveLaw:
+class NamedConstitutiveLaw(MBEntity):
     """
-    Class to encapsulate logic for handling named constitutive laws.
-    Issues a warning if the input is not a ConstitutiveLaw instance.
+    Adapter for using a constitutive law that is not yet implemented in the preprocessor
+    as a regular `ConstitutiveLaw` subclass with argument checking.
+
+    This should only be used temporarily, and may be removed in the future without prior notice.
     """
+    
+    content: str
+    """Text that will be output to MBDyn for this law"""
 
     def __init__(self, law: Union[str, list]):
-        if isinstance(law, str):
-            warnings.warn(
-                "Using a string for constitutive laws is not recommended."
-                "Consider using ConstitutiveLaw instances for better support.",
-                UserWarning
-            )
-            self.law = law
-        elif isinstance(law, list):
-            warnings.warn(
-                "Using a list for constitutive laws is not recommended."
-                "Consider using ConstitutiveLaw instances for better support.",
-                UserWarning
-            )
-            self.law = ', '.join(str(i) for i in law)
+        warnings.warn(
+            "Using a string for constitutive laws is not recommended " + \
+            "and may be removed in the future. " + \
+            "Consider using ConstitutiveLaw instances for better support.",
+            UserWarning
+        )
+        if isinstance(law, list):
+            self.content = ', '.join(str(l) for l in law)
+        else:
+            self.content = str(law)
 
     def __str__(self):
-        return self.law
+        return self.content
 
 DeformableAxial.model_rebuild()
 DeformableHinge2.model_rebuild()


### PR DESCRIPTION
The main idea was good, and also doing the warning, thanks!

Minor changes from me:
- in previous code if the `law` argument wasn't a `str` or `list`, nothing would happen in `__init__` and the error would be thrown later on call to `__str__` because `self.law` would stay undefined
- reworded the strings a bit so that they are descriptive also to someone who didn't see our discussion in chat :wink:
- changed to just one warning for simplicity, because even if you pass a list it will ultimately just become a string
