### PR TITLE
Remove unused empty lists in Python preprocessor

### DIFF
--- a/contrib/PythonPreprocessor/MBDynPreprocess.py
+++ b/contrib/PythonPreprocessor/MBDynPreprocess.py
@@ -71,11 +71,6 @@ elif len(sys.argv) == 3:
         echo = False
 preprocessing_include = re.compile("[\s]*include:")
 
-nodes = []
-bodies = []
-joints = []
-shells = []
-beams = []
 
 class PreProc:
     def __init__(self, echo):


### PR DESCRIPTION
Removed empty lists (nodes, bodies, joints, shells, beams) in MBDynPreprocess.py
since they were not used anywhere. This cleans up the code without affecting functionality.
